### PR TITLE
Determines the IPFS binary path dynamically.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var rimraf = require('rimraf')
 var fs = require('fs')
 var path = require('path')
 
-var IPFS_EXEC = path.join(requireResolve('go-ipfs').pkg.root, '/bin/ipfs'))
+var IPFS_EXEC = path.join(requireResolve('go-ipfs').pkg.root, '/bin/ipfs')
 var GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
 
 function configureNode (node, conf, cb) {

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@ var run = require('subcomandante')
 var _ = require('lodash')
 var Q = require('kew')
 var ipfs = require('ipfs-api')
+var requireResolve = require('require-resolve')
 var waterfall = require('promise-waterfall')
 var shutdown = require('shutdown-handler')
 var rimraf = require('rimraf')
 var fs = require('fs')
+var path = require('path')
 
-var IPFS_EXEC = __dirname + '/node_modules/.bin/ipfs'
+var IPFS_EXEC = path.join(requireResolve('go-ipfs').pkg.root, '/bin/ipfs'))
 var GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
 
 function configureNode (node, conf, cb) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "kew": "0.5.0",
     "lodash": "3.6.0",
     "promise-waterfall": "0.1.0",
+    "require-resolve": "0.0.2",
     "rimraf": "2.3.4",
     "shutdown-handler": "1.0.1",
     "subcomandante": "^1.0.3"


### PR DESCRIPTION
This makes the path valid regardless of whether 'ipfs-api' is a child module of this module, or of one of this module's parents.

Resolves #13.