### PR TITLE
Update package.json to use semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   "license": "MIT",
   "dependencies": {
     "go-ipfs": "0.3.7-3",
-    "ipfs-api": "2.2.1",
-    "kew": "0.5.0",
-    "lodash": "3.6.0",
+    "ipfs-api": "^2.2.1",
+    "kew": "0.7.0",
+    "lodash": "^3.6.0",
     "multiaddr": "^1.0.0",
     "promise-waterfall": "0.1.0",
-    "rimraf": "2.3.4",
-    "shutdown-handler": "1.0.1",
+    "rimraf": "^2.3.4",
+    "shutdown-handler": "^1.0.1",
     "subcomandante": "^1.0.3"
   },
   "devDependencies": {
-    "mocha": "2.2.5"
+    "mocha": "^2.3.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Maybe there is a reason you are not using semver ranges on the dependencies, but this patch fixes that!  Feel free to reject if this isn't wanted.